### PR TITLE
Support for not wanting json

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -60,6 +60,15 @@ const requestFactory = (meth, notify = null) => {
       method: meth,
       body: body
     }).then(resp => {
+      // If the user does not want response converted to json include a "json": false mapping in the arguments[3]
+      if ("json" in options && options["json"] === false){
+        if (resp.status < 200 || resp.status > 300) {
+          if (notify) notify('Received unexpected response from the server.');
+          throw new Non200Error(resp.status, json);
+        }
+        return Promise.resolve(resp.text());
+      }
+
       return resp.json().catch(() => {
         if (notify)
           notify('Received unexpected response from the server.')

--- a/src/index.js
+++ b/src/index.js
@@ -61,12 +61,12 @@ const requestFactory = (meth, notify = null) => {
       body: body
     }).then(resp => {
       // If the user does not want response converted to json include a "json": false mapping in the arguments[3]
-      if ("json" in options && options["json"] === false){
+      if ('json' in options && options['json'] === false){
         if (resp.status < 200 || resp.status > 300) {
-          if (notify) notify('Received unexpected response from the server.');
-          throw new Non200Error(resp.status, json);
+          if (notify) notify('Received unexpected response from the server.')
+          throw new Non200Error(resp.status, resp.text())
         }
-        return Promise.resolve(resp.text());
+        return Promise.resolve(resp.text())
       }
 
       return resp.json().catch(() => {


### PR DESCRIPTION
By adding a `json: false` option in the `options` object, the response is not converted to json